### PR TITLE
chore: bump some versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24.4-bookworm AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-bookworm AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /opt/mdai-s3-logs-reader

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ A lightweight Go API for retrieving and transforming OpenTelemetry-formatted log
 ### Set up API for pulling logs from S3-compatible storage
 - Create Docker image
   ```bash
-  docker build -t mdai-s3-logs-reader:0.0.5 .
+  docker build -t mdai-s3-logs-reader:0.0.6 .
   ```
 - Load Docker image into kind cluster
   ```bash
-  kind load docker-image mdai-s3-logs-reader:0.0.5 --name mdai
+  kind load docker-image mdai-s3-logs-reader:0.0.6 --name mdai
   ```
 - Create a `secret.yaml` using template in [mdai-labs](https://github.com/DecisiveAI/mdai-labs/blob/main/mdai/hub_monitor/mdai_monitor.yaml)
 - Apply the `secret.yaml` to the cluster

--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.5"
+appVersion: "0.0.6"

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -5,4 +5,4 @@ name: mdai-s3-logs-reader
 #awsAccessKeySecret: "aws-credentials"
 image:
   repository: public.ecr.aws/decisiveai/mdai-s3-logs-reader
-  # tag: 0.0.5
+  # tag: 0.0.6


### PR DESCRIPTION
>CVE-2025-47907 affects Go's database/sql package in all versions prior to 1.24.6 and 1.23.12. Any Go application using the standard database/sql package for concurrent queries with context cancellation is potentially vulnerable. Most database drivers that rely on the standard package are impacted, including but not limited to MySQL and PostgreSQL drivers.

> Affected: Go 1.24.5 and earlier, Go 1.23.11 and earlier
> Fixed: Go 1.24.6 and Go 1.23.12

this code does not utilize `database/sql` but does use an affected version of golang which triggers some vulnerability scanners. at the time of this writing, `golang:1.24-bookworm` is `1.24.7` which will satisfy the fixed version.